### PR TITLE
Pr adjustment/integration tests new schema

### DIFF
--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -16,13 +16,13 @@ integration_tests:
       pass: "{{ env_var('CI_REDSHIFT_DBT_PASS') }}"
       dbname: "{{ env_var('CI_REDSHIFT_DBT_DBNAME') }}"
       port: 5439
-      schema: app_reporting_integrations_test
+      schema: app_reporting_integrations_test_1
       threads: 8
     bigquery:
       type: bigquery
       method: service-account-json
       project: 'dbt-package-testing'
-      schema: app_reporting_integrations_test
+      schema: app_reporting_integrations_test_1
       threads: 8
       keyfile_json: "{{ env_var('GCLOUD_SERVICE_KEY') | as_native }}"
     snowflake:
@@ -33,7 +33,7 @@ integration_tests:
       role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
       database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
       warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
-      schema: app_reporting_integrations_test
+      schema: app_reporting_integrations_test_1
       threads: 8
     postgres:
       type: postgres
@@ -42,13 +42,13 @@ integration_tests:
       pass: "{{ env_var('CI_POSTGRES_DBT_PASS') }}"
       dbname: "{{ env_var('CI_POSTGRES_DBT_DBNAME') }}"
       port: 5432
-      schema: app_reporting_integrations_test
+      schema: app_reporting_integrations_test_1
       threads: 8
     databricks:
       catalog: null
       host: "{{ env_var('CI_DATABRICKS_DBT_HOST') }}"
       http_path: "{{ env_var('CI_DATABRICKS_DBT_HTTP_PATH') }}"
-      schema: app_reporting_integrations_test
+      schema: app_reporting_integrations_test_1
       threads: 2
       token: "{{ env_var('CI_DATABRICKS_DBT_TOKEN') }}"
       type: databricks

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -4,8 +4,8 @@ profile: 'integration_tests'
 config-version: 2
 
 vars: 
-  google_play_schema: app_reporting_integrations_test
-  apple_store_schema: app_reporting_integrations_test
+  google_play_schema: app_reporting_integrations_test_1
+  apple_store_schema: app_reporting_integrations_test_1
   google_play_source:
     stats_installs_app_version_identifier: "stats_installs_app_version"
     stats_crashes_app_version_identifier: "stats_crashes_app_version"


### PR DESCRIPTION
Small change in order to ensure the integration tests within PR #14 were resolved. It seems there were some restrictions originally set on the base table which was not allowing us to delete the schema after integration tests 